### PR TITLE
Make menu list sticky on desktop

### DIFF
--- a/style.css
+++ b/style.css
@@ -153,6 +153,13 @@ body {
   padding: 1.5rem; /* consistent card spacing */
 }
 
+@media (min-width: 769px) {
+  .menu-card {
+    position: sticky; /* keep menu in view as the form scrolls */
+    top: 1.5rem;
+  }
+}
+
 /* Placeholder menu list styling */
 .menu-list {
   display: flex;


### PR DESCRIPTION
## Summary
- keep `.menu-card` visible during scrolling on larger screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850cf25999c8323a36dba2f92f001bb