### PR TITLE
Add expandable menu details

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,26 @@
             <form id="recipeForm" novalidate>
                 <input type="hidden" id="eventName" name="eventName" readonly>
                 <input type="hidden" id="eventDate" name="eventDate" readonly>
-                <div class="form-group">
-                    <label for="member">Who are you? *</label>
-                    <input id="member" name="member" list="member-list" placeholder="Start typing your name…" required>
-                    <datalist id="member-list"></datalist>
+                <input type="hidden" id="audienceType" name="audienceType" value="member">
+
+                <div id="member-form">
+                    <div class="form-group">
+                        <label for="member">Who are you? *</label>
+                        <input id="member" name="member" list="member-list" placeholder="Start typing your name…" required>
+                        <datalist id="member-list"></datalist>
+                    </div>
+                    <button type="button" id="switch-to-guest-btn" class="switch-link">Not a Discord member? RSVP as a guest.</button>
+                </div>
+
+                <div id="guest-form" style="display:none;">
+                    <div class="form-group">
+                        <label for="guestName">Your Name: *</label>
+                        <input id="guestName" name="guestName" type="text" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="guestEmail">Your Email (optional):</label>
+                        <input id="guestEmail" name="guestEmail" type="email">
+                    </div>
                 </div>
                 <div class="form-group">
                     <label>How are you joining? *</label>

--- a/script.js
+++ b/script.js
@@ -178,6 +178,9 @@ class RecipeSignupForm {
         this.form = document.getElementById('recipeForm');
         this.memberInput = document.getElementById('member');
         this.memberList = document.getElementById('member-list');
+        this.guestName = document.getElementById('guestName');
+        this.guestEmail = document.getElementById('guestEmail');
+        this.audienceField = document.getElementById('audienceType');
         this.cookingRadios = document.querySelectorAll('input[name="cooking"]');
         this.recipeInput = document.getElementById('recipe');
         this.recipeGroup = document.getElementById('recipeGroup');
@@ -220,6 +223,13 @@ class RecipeSignupForm {
         this.form.addEventListener('submit', (e) => this.handleSubmit(e));
         this.memberInput.addEventListener('input', () => this.validateForm());
         this.memberInput.addEventListener('change', () => this.validateForm());
+        if (this.guestName) {
+            this.guestName.addEventListener('input', () => this.validateForm());
+            this.guestName.addEventListener('change', () => this.validateForm());
+        }
+        if (this.guestEmail) {
+            this.guestEmail.addEventListener('input', () => this.validateForm());
+        }
         
         // Set event name
         document.getElementById('eventName').value = CONFIG.EVENT.name;
@@ -398,14 +408,21 @@ class RecipeSignupForm {
     }
     
     validateForm() {
-        const memberSelected = this.members.some(m => m.displayName === this.memberInput.value);
+        const audience = this.audienceField ? this.audienceField.value : 'member';
+        let nameValid = false;
+        if (audience === 'member') {
+            nameValid = this.members.some(m => m.displayName === this.memberInput.value);
+        } else {
+            nameValid = this.guestName && this.guestName.value.trim() !== '';
+        }
+
         const cookingValue = this.getCookingValue();
         const cookingSelected = cookingValue !== '';
         const recipeSelected = cookingValue === 'no' || this.recipes.some(r => r.name === this.recipeInput.value);
 
-        const isValid = memberSelected && cookingSelected && recipeSelected;
+        const isValid = nameValid && cookingSelected && recipeSelected;
         this.submitBtn.disabled = !isValid;
-        
+
         return isValid;
     }
     
@@ -466,6 +483,7 @@ class RecipeSignupForm {
     //     };
 
     getFormData() {
+        const audience    = this.audienceField ? this.audienceField.value : 'member';
         const member      = this.members.find(m => m.displayName === this.memberInput.value.trim());
         const cookingFlag = this.getCookingValue() === 'yes';
         const recipeInput = this.recipeInput.value.trim();
@@ -474,21 +492,22 @@ class RecipeSignupForm {
             ? this.recipes.find(r => r.name === recipeInput)
             : null;
 
-        // Always include note and recordUrl so Apps-Script can decide how to display them
         const note      = this.notesField.value.trim();
         const recordUrl = selectedRecipe ? (selectedRecipe.recordUrl || '') : '';
 
         return {
-            eventName : document.getElementById('eventName').value,
-            eventDate : document.getElementById('eventDate').value,
-            discordId : member ? member.discordId : '',
-            displayName: member ? member.displayName : '',
-            cooking   : cookingFlag,
-            recipeId  : selectedRecipe ? Number(selectedRecipe.id) : null,
-            recipeName: selectedRecipe ? selectedRecipe.name : '',
+            eventName   : document.getElementById('eventName').value,
+            eventDate   : document.getElementById('eventDate').value,
+            audienceType: audience,
+            discordId   : audience === 'member' && member ? member.discordId : '',
+            displayName : audience === 'member' && member ? member.displayName : (this.guestName ? this.guestName.value.trim() : ''),
+            guestEmail  : audience === 'guest' && this.guestEmail ? this.guestEmail.value.trim() : '',
+            cooking     : cookingFlag,
+            recipeId    : selectedRecipe ? Number(selectedRecipe.id) : null,
+            recipeName  : selectedRecipe ? selectedRecipe.name : '',
             recordUrl,
             note,
-            timestamp : new Date().toISOString()
+            timestamp   : new Date().toISOString()
         };
     }
 
@@ -735,6 +754,46 @@ class RecipeSignupForm {
 
 // Initialize the form when the page loads
 document.addEventListener('DOMContentLoaded', () => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const guestCode = urlParams.get('g');
+    const memberForm = document.getElementById('member-form');
+    const guestForm = document.getElementById('guest-form');
+    const switchToGuestBtn = document.getElementById('switch-to-guest-btn');
+    const audienceField = document.getElementById('audienceType');
+
+    function showMemberUI() {
+        if (memberForm) memberForm.style.display = 'block';
+        if (guestForm) guestForm.style.display = 'none';
+        if (audienceField) audienceField.value = 'member';
+        if (!guestCode) {
+            localStorage.removeItem('audienceMode');
+        }
+    }
+
+    function showGuestUI(code = 'public') {
+        if (memberForm) memberForm.style.display = 'none';
+        if (guestForm) guestForm.style.display = 'block';
+        if (audienceField) audienceField.value = 'guest';
+        localStorage.setItem('audienceMode', 'guest');
+        console.log(`Showing Guest UI for code: ${code}`);
+    }
+
+    if (guestCode) {
+        showGuestUI(guestCode);
+    } else if (localStorage.getItem('audienceMode') === 'guest') {
+        showGuestUI('localStorage');
+    } else {
+        showMemberUI();
+    }
+
+    if (switchToGuestBtn) {
+        switchToGuestBtn.addEventListener('click', () => {
+            const newUrl = new URL(window.location.href);
+            newUrl.searchParams.set('g', 'public');
+            window.location.href = newUrl.toString();
+        });
+    }
+
     new RecipeSignupForm();
     renderEmptyMenuMessage();
     // pull accent color from the displayed book cover

--- a/script.js
+++ b/script.js
@@ -634,6 +634,7 @@ class RecipeSignupForm {
         const nameDiv = document.createElement('div');
         nameDiv.className = 'recipe-name';
         nameDiv.textContent = recipe.name;
+
         header.appendChild(nameDiv);
 
         if (recipe.page) {

--- a/script.js
+++ b/script.js
@@ -391,111 +391,7 @@ class RecipeSignupForm {
     }
 
     renderRecipeEntry(recipe) {
-        const entry = document.createElement('div');
-        entry.className = 'recipe-entry';
-
-        // Title
-        const title = document.createElement('div');
-        title.className = 'title';
-        title.textContent = recipe.name || '';
-        entry.appendChild(title);
-
-        // Page
-        if (recipe.page) {
-            const row = document.createElement('div');
-            row.className = 'meta-row';
-
-            const label = document.createElement('span');
-            label.className = 'label';
-            label.textContent = 'Page'; 
-            row.appendChild(label);
-
-            const pill = document.createElement('span');
-            pill.className = 'page-pill';
-            pill.textContent = recipe.page; // page number only
-            row.appendChild(pill);
-
-            entry.appendChild(row);
-        }
-
-        // Categories
-        let categories = recipe.categories;
-        if (Array.isArray(categories)) {
-            categories = categories.flatMap(cat => String(cat).split(';'));
-        } else if (typeof categories === 'string') {
-            categories = categories.split(';');
-        }
-        categories = categories.map(c => String(c).trim()).filter(Boolean);
-        if (Array.isArray(categories) && categories.length) {
-            const row = document.createElement('div');
-            row.className = 'meta-row';
-
-            const label = document.createElement('span');
-            label.className = 'label';
-            label.textContent = 'Categories';
-            row.appendChild(label);
-
-            const pillContainer = document.createElement('span');
-            row.appendChild(pillContainer);
-
-            // Render pastel pills for each category
-            renderCategoryPills(categories, pillContainer);
-
-            entry.appendChild(row);
-        }
-
-        // Ingredients
-        let ingredientsText = recipe.ingredients;
-        if (Array.isArray(ingredientsText)) {
-            ingredientsText = ingredientsText.join('; ');
-        }
-        if (ingredientsText) {
-            const row = document.createElement('div');
-            row.className = 'meta-row ingredients';
-
-            const label = document.createElement('span');
-            label.className = 'label';
-            label.textContent = 'Ingredients';
-            row.appendChild(label);
-
-            const textSpan = document.createElement('span');
-            textSpan.id = 'ingredient-text';
-            textSpan.className = 'ingredient-text collapsed';
-            textSpan.textContent = ingredientsText;
-            row.appendChild(textSpan);
-
-            const button = document.createElement('button');
-            button.type = 'button';
-            button.className = 'toggle-button';
-            button.setAttribute('aria-expanded', 'false');
-            button.setAttribute('aria-controls', 'ingredient-text');
-            button.textContent = 'Show more';
-            button.addEventListener('click', () => toggleIngredientText());
-            row.appendChild(button);
-
-            entry.appendChild(row);
-        }
-
-        // Accompaniments
-        let accompanimentsText = recipe.accompaniments;
-        if (Array.isArray(accompanimentsText)) {
-            accompanimentsText = accompanimentsText.join('; ');
-        }
-        if (accompanimentsText) {
-            const row = document.createElement('div');
-            row.className = 'meta-row';
-
-            const label = document.createElement('span');
-            label.className = 'label';
-            label.textContent = 'Accompaniments';
-            row.appendChild(label);
-
-            const textSpan = document.createElement('span');
-            textSpan.textContent = accompanimentsText;
-            row.appendChild(textSpan);
-
-            entry.appendChild(row);
-        }
+        const entry = buildRecipeDetails(recipe);
 
         this.recipeEntry.innerHTML = '';
         this.recipeEntry.appendChild(entry);
@@ -730,8 +626,10 @@ class RecipeSignupForm {
         const item = document.createElement('div');
         item.className = 'menu-item dish-card';
 
-        const header = document.createElement('div');
+        const header = document.createElement('button');
+        header.type = 'button';
         header.className = 'menu-item-header';
+        header.setAttribute('aria-expanded', 'false');
 
         const nameDiv = document.createElement('div');
         nameDiv.className = 'recipe-name';
@@ -773,6 +671,17 @@ class RecipeSignupForm {
             flag.textContent = '🌱';
             item.appendChild(flag);
         }
+
+        const details = buildRecipeDetails(recipe);
+        details.classList.add('recipe-details');
+        details.style.display = 'none';
+        item.appendChild(details);
+
+        header.addEventListener('click', () => {
+            const expanded = item.classList.toggle('open');
+            header.setAttribute('aria-expanded', expanded);
+            details.style.display = expanded ? 'block' : 'none';
+        });
 
         return item;
     }
@@ -856,5 +765,114 @@ function toggleIngredientText() {
     }
     button.textContent = expanded ? 'Show less' : 'Show more';
     button.setAttribute('aria-expanded', expanded);
+}
+
+// Build a DOM node with full recipe details
+function buildRecipeDetails(recipe) {
+    const entry = document.createElement('div');
+    entry.className = 'recipe-entry';
+
+    const title = document.createElement('div');
+    title.className = 'title';
+    title.textContent = recipe.name || '';
+    entry.appendChild(title);
+
+    if (recipe.page) {
+        const row = document.createElement('div');
+        row.className = 'meta-row';
+
+        const label = document.createElement('span');
+        label.className = 'label';
+        label.textContent = 'Page';
+        row.appendChild(label);
+
+        const pill = document.createElement('span');
+        pill.className = 'page-pill';
+        pill.textContent = recipe.page;
+        row.appendChild(pill);
+
+        entry.appendChild(row);
+    }
+
+    let categories = recipe.categories;
+    if (Array.isArray(categories)) {
+        categories = categories.flatMap(cat => String(cat).split(';'));
+    } else if (typeof categories === 'string') {
+        categories = categories.split(';');
+    }
+    categories = categories.map(c => String(c).trim()).filter(Boolean);
+    if (categories.length) {
+        const row = document.createElement('div');
+        row.className = 'meta-row';
+
+        const label = document.createElement('span');
+        label.className = 'label';
+        label.textContent = 'Categories';
+        row.appendChild(label);
+
+        const pillContainer = document.createElement('span');
+        row.appendChild(pillContainer);
+        renderCategoryPills(categories, pillContainer);
+
+        entry.appendChild(row);
+    }
+
+    let ingredientsText = recipe.ingredients;
+    if (Array.isArray(ingredientsText)) {
+        ingredientsText = ingredientsText.join('; ');
+    }
+    if (ingredientsText) {
+        const row = document.createElement('div');
+        row.className = 'meta-row';
+
+        const label = document.createElement('span');
+        label.className = 'label';
+        label.textContent = 'Ingredients';
+        row.appendChild(label);
+
+        const textSpan = document.createElement('span');
+        textSpan.textContent = ingredientsText;
+        row.appendChild(textSpan);
+
+        entry.appendChild(row);
+    }
+
+    let accompanimentsText = recipe.accompaniments;
+    if (Array.isArray(accompanimentsText)) {
+        accompanimentsText = accompanimentsText.join('; ');
+    }
+    if (accompanimentsText) {
+        const row = document.createElement('div');
+        row.className = 'meta-row';
+
+        const label = document.createElement('span');
+        label.className = 'label';
+        label.textContent = 'Accompaniments';
+        row.appendChild(label);
+
+        const textSpan = document.createElement('span');
+        textSpan.textContent = accompanimentsText;
+        row.appendChild(textSpan);
+
+        entry.appendChild(row);
+    }
+
+    if (recipe.note) {
+        const row = document.createElement('div');
+        row.className = 'meta-row';
+
+        const label = document.createElement('span');
+        label.className = 'label';
+        label.textContent = 'Note';
+        row.appendChild(label);
+
+        const textSpan = document.createElement('span');
+        textSpan.textContent = recipe.note;
+        row.appendChild(textSpan);
+
+        entry.appendChild(row);
+    }
+
+    return entry;
 }
 

--- a/script.js
+++ b/script.js
@@ -366,7 +366,7 @@ class RecipeSignupForm {
                 radio.parentElement.classList.remove('selected');
             }
         });
-        const isCooking = value === 'yes';
+        const entry = buildRecipeDetails(recipe, true);
         
         if (isCooking) {
             this.recipeGroup.style.display = 'block';
@@ -647,7 +647,7 @@ class RecipeSignupForm {
 
         const header = document.createElement('button');
         header.type = 'button';
-        header.className = 'menu-item-header';
+        const details = buildRecipeDetails(recipe, false);
         header.setAttribute('aria-expanded', 'false');
 
         const headerInfo = document.createElement('div');
@@ -743,11 +743,13 @@ class RecipeSignupForm {
             item.addEventListener('click', () => {
                 this.recipeInput.value = recipe.name;
                 this.handleRecipeChange();
-                this.closeRecipeModal();
-                if (this.changeRecipeLink) this.changeRecipeLink.style.display = 'block';
-            });
-            this.recipeModalList.appendChild(item);
-        });
+function buildRecipeDetails(recipe, includeTitle = true) {
+    if (includeTitle) {
+        const title = document.createElement('div');
+        title.className = 'title';
+        title.textContent = recipe.name || '';
+        entry.appendChild(title);
+    }
     }
 
     getMemberName(discordId) {

--- a/script.js
+++ b/script.js
@@ -650,20 +650,13 @@ class RecipeSignupForm {
         header.className = 'menu-item-header';
         header.setAttribute('aria-expanded', 'false');
 
+        const headerInfo = document.createElement('div');
+        headerInfo.className = 'menu-header-info';
+
         const nameDiv = document.createElement('div');
         nameDiv.className = 'recipe-name';
         nameDiv.textContent = recipe.name;
-
-        header.appendChild(nameDiv);
-
-        if (recipe.page) {
-            const pageDiv = document.createElement('div');
-            pageDiv.className = 'page-pill';
-            pageDiv.textContent = `p${recipe.page}`; // shorter label
-            header.appendChild(pageDiv);
-        }
-
-        item.appendChild(header);
+        headerInfo.appendChild(nameDiv);
 
         let claimedBy = recipe.claimedBy || '';
         if (!claimedBy && recipe.claimedByDiscordId) {
@@ -673,8 +666,19 @@ class RecipeSignupForm {
             const claimDiv = document.createElement('div');
             claimDiv.className = 'claimed-by';
             claimDiv.textContent = `Claimed by ${claimedBy}`;
-            item.appendChild(claimDiv);
+            headerInfo.appendChild(claimDiv);
         }
+
+        header.appendChild(headerInfo);
+
+        if (recipe.page) {
+            const pageDiv = document.createElement('div');
+            pageDiv.className = 'page-pill';
+            pageDiv.textContent = `p${recipe.page}`; // shorter label
+            header.appendChild(pageDiv);
+        }
+
+        item.appendChild(header);
 
         const course = detectCourse(recipe);
         if (course) {

--- a/style.css
+++ b/style.css
@@ -193,6 +193,12 @@ body {
   cursor: pointer;
 }
 
+.menu-header-info {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
 .menu-item-header::after {
   content: "\25BC"; /* downward triangle */
   font-size: 0.8rem;
@@ -235,6 +241,7 @@ body {
 .menu-item .claimed-by {
   color: #555;
   font-size: 0.9rem;
+  margin-top: 2px;
 }
 
   .page-pill {

--- a/style.css
+++ b/style.css
@@ -185,6 +185,32 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.menu-item-header::after {
+  content: "\25BC"; /* downward triangle */
+  font-size: 0.8rem;
+  margin-left: 6px;
+  transition: transform 0.2s ease;
+}
+
+.menu-item.open .menu-item-header::after {
+  transform: rotate(180deg);
+}
+
+.recipe-details {
+  display: none;
+  margin-top: 0.75rem;
+}
+
+.menu-item.open .recipe-details {
+  display: block;
 }
 
 .menu-item:last-child {

--- a/style.css
+++ b/style.css
@@ -563,6 +563,18 @@ button:disabled {
   cursor: pointer;
 }
 
+/* Link-style button for audience switch */
+.switch-link {
+  margin: 0.5rem 0;
+  background: none;
+  border: none;
+  color: #007aff;
+  font-size: 0.9rem;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+}
+
 /* Recipe picker modal / sheet */
 .recipe-modal {
   position: fixed;


### PR DESCRIPTION
## Summary
- enable menu item cards to toggle expanded recipe details
- render details using new helper `buildRecipeDetails`
- style header arrow and hidden detail section

## Testing
- `npm test` *(fails: No tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_68520c5d7dc08323a4d0a7313e38365b