### PR TITLE
Display claimed names on menu cards

### DIFF
--- a/script.js
+++ b/script.js
@@ -631,20 +631,13 @@ class RecipeSignupForm {
         header.className = 'menu-item-header';
         header.setAttribute('aria-expanded', 'false');
 
+        const headerInfo = document.createElement('div');
+        headerInfo.className = 'menu-header-info';
+
         const nameDiv = document.createElement('div');
         nameDiv.className = 'recipe-name';
         nameDiv.textContent = recipe.name;
-
-        header.appendChild(nameDiv);
-
-        if (recipe.page) {
-            const pageDiv = document.createElement('div');
-            pageDiv.className = 'page-pill';
-            pageDiv.textContent = `p${recipe.page}`; // shorter label
-            header.appendChild(pageDiv);
-        }
-
-        item.appendChild(header);
+        headerInfo.appendChild(nameDiv);
 
         let claimedBy = recipe.claimedBy || '';
         if (!claimedBy && recipe.claimedByDiscordId) {
@@ -654,8 +647,19 @@ class RecipeSignupForm {
             const claimDiv = document.createElement('div');
             claimDiv.className = 'claimed-by';
             claimDiv.textContent = `Claimed by ${claimedBy}`;
-            item.appendChild(claimDiv);
+            headerInfo.appendChild(claimDiv);
         }
+
+        header.appendChild(headerInfo);
+
+        if (recipe.page) {
+            const pageDiv = document.createElement('div');
+            pageDiv.className = 'page-pill';
+            pageDiv.textContent = `p${recipe.page}`; // shorter label
+            header.appendChild(pageDiv);
+        }
+
+        item.appendChild(header);
 
         const course = detectCourse(recipe);
         if (course) {

--- a/style.css
+++ b/style.css
@@ -193,6 +193,12 @@ body {
   cursor: pointer;
 }
 
+.menu-header-info {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
 .menu-item-header::after {
   content: "\25BC"; /* downward triangle */
   font-size: 0.8rem;
@@ -235,6 +241,7 @@ body {
 .menu-item .claimed-by {
   color: #555;
   font-size: 0.9rem;
+  margin-top: 2px;
 }
 
   .page-pill {


### PR DESCRIPTION
## Summary
- show "claimed by" names inside menu header so they're visible when collapsed
- style header info container and spacing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852355563a08323a4b7b99ba8b6d9bd