### PR TITLE
Fix duplicate variable causing menu load failure

### DIFF
--- a/script.js
+++ b/script.js
@@ -647,7 +647,7 @@ class RecipeSignupForm {
 
         const header = document.createElement('button');
         header.type = 'button';
-        const details = buildRecipeDetails(recipe, false);
+        header.className = 'menu-item-header';
         header.setAttribute('aria-expanded', 'false');
 
         const headerInfo = document.createElement('div');


### PR DESCRIPTION
## Summary
- remove stray `details` variable inside `renderDishCard`
- restore `.menu-item-header` class for header buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685239edd70c83239056f08ec602d3a9