### PR TITLE
Fix duplicate variable causing menu load failure

### DIFF
--- a/script.js
+++ b/script.js
@@ -647,7 +647,7 @@ class RecipeSignupForm {
 
         const header = document.createElement('button');
         header.type = 'button';
-        const details = buildRecipeDetails(recipe, false);
+        header.className = 'menu-item-header';
         header.setAttribute('aria-expanded', 'false');
 
         const headerInfo = document.createElement('div');
@@ -743,13 +743,11 @@ class RecipeSignupForm {
             item.addEventListener('click', () => {
                 this.recipeInput.value = recipe.name;
                 this.handleRecipeChange();
-function buildRecipeDetails(recipe, includeTitle = true) {
-    if (includeTitle) {
-        const title = document.createElement('div');
-        title.className = 'title';
-        title.textContent = recipe.name || '';
-        entry.appendChild(title);
-    }
+                this.closeRecipeModal();
+                if (this.changeRecipeLink) this.changeRecipeLink.style.display = 'block';
+            });
+            this.recipeModalList.appendChild(item);
+        });
     }
 
     getMemberName(discordId) {


### PR DESCRIPTION
## Summary
- remove stray `details` variable inside `renderDishCard`
- restore `.menu-item-header` class for header buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685239edd70c83239056f08ec602d3a9