### PR TITLE
Handle guest query parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
                 <input type="hidden" id="eventName" name="eventName" readonly>
                 <input type="hidden" id="eventDate" name="eventDate" readonly>
                 <input type="hidden" id="audienceType" name="audienceType" value="member">
+                <input type="hidden" id="audienceCode" name="audienceCode" value="">
 
                 <div id="member-form">
                     <div class="form-group">


### PR DESCRIPTION
## Summary
- store guest group code in a hidden field
- capture guest code when `g` query parameter is present and persist it
- include the code in form submissions
- validate `g` query parameter against allowed guest codes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852508ece188323bc2e5e1ef3137efa