### PR TITLE
Add dish card hover styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -178,7 +178,8 @@ body {
   border-radius: 8px;
   padding: 1rem;
   margin-bottom: 12px;
-  transition: box-shadow 0.2s ease;
+  transition: box-shadow 0.2s ease, background-color 0.2s ease,
+    border-radius 0.2s ease;
 }
 
 .menu-item-header {
@@ -261,6 +262,11 @@ body {
 .dish-card {
   position: relative;
   padding-left: 1rem;
+}
+
+.dish-card:hover {
+  background-color: #f5f5f5; /* subtle shift */
+  border-radius: 10px;        /* 2px more than default */
 }
 
 .dish-card::before {


### PR DESCRIPTION
## Summary
- smooth transition effects for menu item cards
- add subtle background highlight and border-radius increase on hover

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852570190308323aa92454972b9a235