### PR TITLE
Add animated RSVP confirmation

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,11 @@
             </div>
         </div>
         </div>
+        <!-- Confirmation message shown after successful RSVP -->
+        <div id="confirmation" class="confirmation-message">
+            <h2 id="confirmationHeading">You're In! Get Ready to Feast!</h2>
+            <p>Your RSVP is confirmed. See you soon!</p>
+        </div>
     </div>
     </div>
 
@@ -101,6 +106,7 @@
     </div>
 
     <script src="config.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -482,9 +482,9 @@ class RecipeSignupForm {
             // Submit to Google Apps Script
             await this.submitToGoogleSheets(formData);
             
-            this.showMessage(CONFIG.MESSAGES.SUCCESS, 'success');
+            this.showConfirmation();
             this.resetForm();
-            
+
             // Reload data to get updated recipe list
             await this.loadData();
             
@@ -649,6 +649,21 @@ class RecipeSignupForm {
     hideMessage() {
         this.messageDiv.style.display = 'none';
         this.messageDiv.className = 'message';
+    }
+
+    showConfirmation() {
+        const formCard = document.querySelector('.form-card');
+        const confirm = document.getElementById('confirmation');
+        if (!formCard || !confirm) return;
+        formCard.classList.add('fade-out');
+        formCard.addEventListener('transitionend', () => {
+            formCard.style.display = 'none';
+            confirm.style.display = 'block';
+            confirm.classList.add('fade-in');
+            if (window.confetti) {
+                window.confetti({ particleCount: 120, spread: 80, origin: { y: 0.6 } });
+            }
+        }, { once: true });
     }
     
     resetForm() {

--- a/style.css
+++ b/style.css
@@ -658,3 +658,31 @@ button:disabled {
   font-size: 1rem;
   cursor: pointer;
 }
+
+/* Confirmation message styles */
+.confirmation-message {
+  text-align: center;
+  padding: 2rem;
+  display: none;
+}
+
+.confirmation-message h2 {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+/* Simple fade animations */
+.fade-out {
+  opacity: 0;
+  transform: translateY(-20px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.fade-in {
+  animation: fadeIn 0.6s forwards;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(20px); }
+  to   { opacity: 1; transform: translateY(0); }
+}


### PR DESCRIPTION
## Summary
- show a confirmation section after the form is submitted
- add fade animations and style for confirmation message
- load canvas-confetti from CDN
- fade out the form and launch confetti on success

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68525cf3b09c8323bcb5c0d32ca7f2ee