### PR TITLE
Implement dish count and course grouping

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,7 @@
 
         <div class="menu-card">
             <h2>Menu In Progress</h2>
+            <div id="dishCount" class="dish-count"></div>
             <div class="menu-list">
                 <!-- menu items will be injected here -->
             </div>

--- a/script.js
+++ b/script.js
@@ -142,13 +142,23 @@ function renderCategoryPills(categories, container) {
 
 // Course and diet helpers ---------------------------------------
 const COURSE_CATEGORIES = {
+    appetizer: ['Appetizer'],
     main: ['Main course', 'Stews & one-pot meals', 'Grills & BBQ', 'Rice dishes', 'Pasta, doughs & sauces'],
     side: ['Side dish', 'Salads', 'Sauces, general', 'Dressings & marinades'],
     dessert: ['Dessert']
 };
 
+const COURSE_ORDER = ['appetizer', 'main', 'side', 'dessert'];
+const COURSE_DISPLAY_NAMES = {
+    appetizer: 'Appetizers',
+    main: 'Main Courses',
+    side: 'Side Dishes',
+    dessert: 'Desserts'
+};
+
 const COURSE_KEYWORDS = {
     dessert: ['cake', 'pie', 'cookie', 'pudding', 'tart', 'brownie'],
+    appetizer: ['dip', 'starter', 'appetizer'],
     main: ['roast', 'steak', 'pasta', 'curry', 'lasagna', 'stew'],
     side: ['salad', 'slaw', 'soup', 'dip', 'side']
 };
@@ -685,10 +695,32 @@ class RecipeSignupForm {
 
         menuList.innerHTML = '';
         const claimedRecipes = this.allRecipes.filter(r => r.claimed);
+        updateDishCount(claimedRecipes.length);
 
+        const groups = {};
         claimedRecipes.forEach(r => {
-            const item = this.renderDishCard(r);
-            menuList.appendChild(item);
+            const key = detectCourse(r) || 'other';
+            if (!groups[key]) groups[key] = [];
+            groups[key].push(r);
+        });
+
+        COURSE_ORDER.forEach(course => {
+            const items = groups[course];
+            if (!items || items.length === 0) return;
+            const section = document.createElement('div');
+            section.className = 'course-section';
+
+            const heading = document.createElement('h3');
+            heading.className = 'course-heading';
+            heading.textContent = COURSE_DISPLAY_NAMES[course] || course;
+            section.appendChild(heading);
+
+            items.forEach(recipe => {
+                const item = this.renderDishCard(recipe);
+                section.appendChild(item);
+            });
+
+            menuList.appendChild(section);
         });
 
         if (claimedRecipes.length === 0) {
@@ -861,9 +893,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
     new RecipeSignupForm();
     renderEmptyMenuMessage();
+    updateDishCount(0);
     // pull accent color from the displayed book cover
     setAccentFromImage('.cover-column img');
 });
+
+function updateDishCount(count) {
+    const el = document.getElementById('dishCount');
+    if (el) {
+        el.textContent = `${count} Dish${count === 1 ? '' : 'es'} Confirmed!`;
+    }
+}
 
 function renderEmptyMenuMessage() {
     const menuList = document.querySelector('.menu-list');

--- a/style.css
+++ b/style.css
@@ -25,6 +25,7 @@ body {
   --course-main: #C9362E;
   --course-side: #3DA351;
   --course-dessert: #F4B84B;
+  --course-appetizer: #0070A3;
   /* accent hue pulled from the current book cover */
   --accent: #6A5AF9;
 }
@@ -172,6 +173,20 @@ body {
   padding: 0;
 }
 
+.dish-count {
+  font-weight: 600;
+  margin-top: 0.25rem;
+}
+
+.course-section + .course-section {
+  margin-top: 1rem;
+}
+
+.course-heading {
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+}
+
 .menu-item {
   background: #fff;
   border: 1px solid #eee;
@@ -279,9 +294,10 @@ body {
   background: var(--course-color, transparent);
 }
 
-.dish-card--main    { --course-color: var(--course-main); }
-.dish-card--side    { --course-color: var(--course-side); }
-.dish-card--dessert { --course-color: var(--course-dessert); }
+.dish-card--main       { --course-color: var(--course-main); }
+.dish-card--side       { --course-color: var(--course-side); }
+.dish-card--dessert    { --course-color: var(--course-dessert); }
+.dish-card--appetizer  { --course-color: var(--course-appetizer); }
 
 .dish-card--veg {
   position: relative;


### PR DESCRIPTION
## Summary
- add visible dish count in the menu card
- group confirmed dishes by course section
- style new menu sections and appetizer accent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685260b30224832393fa9849d4c5367a