### PR TITLE
Add recipe detail modal overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,17 @@
         </div>
     </div>
 
+    <!-- Full screen recipe detail modal -->
+    <div id="recipeDetailModal" class="recipe-detail-modal" aria-hidden="true" role="dialog">
+        <div class="recipe-detail-card" tabindex="-1">
+            <button type="button" id="detailClose" class="detail-close" aria-label="Close">×</button>
+            <div id="recipeDetailContent" class="recipe-detail-content"></div>
+            <div class="detail-actions">
+                <button type="button" id="shareRecipe" class="share-btn">Share</button>
+            </div>
+        </div>
+    </div>
+
     <script src="config.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -282,26 +282,96 @@ function closeAllRecipeCards() {
     });
 }
 
+let lastFocusedElement = null;
+
+function openRecipeDetailModal(recipeId) {
+    const modal = document.getElementById('recipeDetailModal');
+    const content = document.getElementById('recipeDetailContent');
+    const shareBtn = document.getElementById('shareRecipe');
+    if (!modal || !content) return;
+    const recipe = findRecipeById(recipeId);
+    if (!recipe) return;
+
+    content.innerHTML = '';
+
+    const title = document.createElement('h2');
+    title.textContent = getRecipeName(recipe);
+    content.appendChild(title);
+
+    const meta = buildRecipeDetails(recipe);
+    meta.style.marginTop = '16px';
+    content.appendChild(meta);
+
+    const claimDiv = document.createElement('div');
+    claimDiv.className = 'claim-status';
+    if (recipe.claimed) {
+        let claimedBy = recipe.claimedBy || '';
+        if (!claimedBy && recipe.claimedByDiscordId) {
+            const form = window.recipeSignupForm;
+            claimedBy = form ? form.getMemberName(recipe.claimedByDiscordId) || recipe.claimedByDiscordId : recipe.claimedByDiscordId;
+        }
+        claimDiv.textContent = `Claimed by ${claimedBy}`;
+    } else {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'share-btn';
+        btn.textContent = 'Claim this recipe';
+        btn.addEventListener('click', () => {
+            const form = window.recipeSignupForm;
+            if (form) {
+                form.recipeInput.value = getRecipeName(recipe);
+                form.handleRecipeChange();
+            }
+            closeRecipeDetailModal();
+            if (form && form.recipeInput) form.recipeInput.focus();
+        });
+        claimDiv.appendChild(btn);
+    }
+    claimDiv.style.marginTop = '16px';
+    content.appendChild(claimDiv);
+
+    if (shareBtn) {
+        shareBtn.textContent = 'Share';
+        shareBtn.onclick = () => {
+            const url = `${window.location.origin}${window.location.pathname}#/recipe/${recipeId}`;
+            navigator.clipboard.writeText(url).then(() => {
+                shareBtn.textContent = 'Copied!';
+                setTimeout(() => { shareBtn.textContent = 'Share'; }, 2000);
+            });
+        };
+    }
+
+    lastFocusedElement = document.activeElement;
+    modal.classList.add('open');
+    modal.setAttribute('aria-hidden', 'false');
+    const card = modal.querySelector('.recipe-detail-card');
+    if (card) {
+        card.focus();
+        trapFocus(modal);
+    }
+}
+
+function closeRecipeDetailModal() {
+    const modal = document.getElementById('recipeDetailModal');
+    if (!modal || !modal.classList.contains('open')) return;
+    modal.classList.remove('open');
+    modal.setAttribute('aria-hidden', 'true');
+    if (lastFocusedElement) lastFocusedElement.focus();
+    updateURL('');
+}
+
 /** Expand the card corresponding to the given recipe ID. */
 function openRecipeCard(recipeId) {
-    const card = document.querySelector(`.dish-card[data-recipe-id="${recipeId}"]`);
-    if (!card) return;
-    closeAllRecipeCards();
-    const header = card.querySelector('.menu-item-header');
-    const details = card.querySelector('.recipe-details');
-    card.classList.add('open');
-    if (header) header.setAttribute('aria-expanded', 'true');
-    if (details) details.style.display = 'block';
-    card.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    openRecipeDetailModal(recipeId);
 }
 
 /** Respond to hash changes by opening the appropriate card. */
 function handleRouteChange() {
     const route = parseCurrentURL();
     if (route.type === 'recipe') {
-        openRecipeCard(route.id);
+        openRecipeDetailModal(route.id);
     } else {
-        closeAllRecipeCards();
+        closeRecipeDetailModal();
     }
 }
 
@@ -888,14 +958,11 @@ class RecipeSignupForm {
         item.appendChild(details);
 
         header.addEventListener('click', () => {
-            const expanded = item.classList.toggle('open');
-            header.setAttribute('aria-expanded', expanded);
-            details.style.display = expanded ? 'block' : 'none';
-            if (expanded) {
+            const route = parseCurrentURL();
+            if (route.type !== 'recipe' || route.id !== recipeId) {
                 updateURL(recipeId);
-            } else {
-                updateURL('');
             }
+            openRecipeDetailModal(recipeId);
         });
 
         return item;
@@ -1031,6 +1098,20 @@ document.addEventListener('DOMContentLoaded', () => {
     handleRouteChange();
     // pull accent color from the displayed book cover
     setAccentFromImage('.cover-column img');
+
+    const detailModal = document.getElementById('recipeDetailModal');
+    const detailClose = document.getElementById('detailClose');
+    if (detailClose) detailClose.addEventListener('click', () => closeRecipeDetailModal());
+    if (detailModal) {
+        detailModal.addEventListener('click', (e) => {
+            if (e.target === detailModal) closeRecipeDetailModal();
+        });
+    }
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
+            closeRecipeDetailModal();
+        }
+    });
 });
 
 function updateDishCount(count) {
@@ -1171,5 +1252,30 @@ function buildRecipeDetails(recipe) {
     }
 
     return entry;
+}
+
+function trapFocus(modal) {
+    const focusableSelectors = 'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])';
+    const focusable = Array.from(modal.querySelectorAll(focusableSelectors));
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    modal.addEventListener('keydown', function(e) {
+        if (e.key === 'Tab') {
+            if (e.shiftKey) {
+                if (document.activeElement === first) {
+                    e.preventDefault();
+                    last.focus();
+                }
+            } else {
+                if (document.activeElement === last) {
+                    e.preventDefault();
+                    first.focus();
+                }
+            }
+        } else if (e.key === 'Escape') {
+            closeRecipeDetailModal();
+        }
+    });
 }
 

--- a/style.css
+++ b/style.css
@@ -710,3 +710,79 @@ button:disabled {
   from { opacity: 0; transform: translateY(20px); }
   to   { opacity: 1; transform: translateY(0); }
 }
+
+/* Recipe detail modal overlay */
+.recipe-detail-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+  transition: opacity 0.3s ease;
+  opacity: 0;
+}
+.recipe-detail-modal.open {
+  display: flex;
+  opacity: 1;
+}
+
+.recipe-detail-card {
+  background: #fff;
+  color: #2B2B2B;
+  border-radius: 8px;
+  box-shadow: 0 20px 40px rgba(0,0,0,0.15);
+  padding: 32px;
+  max-width: 800px;
+  max-height: 90vh;
+  overflow-y: auto;
+  width: calc(100% - 40px);
+  transform: scale(0.9);
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  opacity: 0;
+}
+.recipe-detail-modal.open .recipe-detail-card {
+  transform: scale(1);
+  opacity: 1;
+}
+
+.detail-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: #444;
+}
+
+.detail-actions {
+  margin-top: 24px;
+  text-align: right;
+}
+
+.claim-status {
+  margin-top: 16px;
+  font-weight: 500;
+}
+
+.share-btn {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+@media (max-width: 768px) {
+  .recipe-detail-card {
+    padding: 20px;
+    width: calc(100% - 20px);
+  }
+}


### PR DESCRIPTION
## Summary
- implement full page recipe detail modal overlay
- add modal styles and responsive behaviors
- integrate modal with routing and recipe cards
- allow sharing and claiming recipes from modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852677127e48323bf21e36908a828b8