### PR TITLE
Add loading overlay container

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,6 +119,11 @@
         </div>
     </div>
 
+    <!-- Loading overlay shown while recipes load -->
+    <div id="loadingOverlay" class="loading-overlay">
+        <p>Just a moment! We’re warming up the kitchen and gathering all the delicious recipes for you…</p>
+    </div>
+
     <script src="config.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
     <script src="script.js"></script>

--- a/style.css
+++ b/style.css
@@ -786,3 +786,29 @@ button:disabled {
     width: calc(100% - 20px);
   }
 }
+
+/* Full-page loading overlay - hidden by default
+   Shows a friendly message while data loads */
+.loading-overlay {
+  position: fixed;
+  inset: 0;
+  display: none; /* Toggle to flex when activated */
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  text-align: center;
+  font-size: 1.25rem;
+  line-height: 1.4;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
+  color: #2B2B2B;
+  z-index: 1200; /* above all content */
+}
+
+@media (prefers-color-scheme: dark) {
+  .loading-overlay {
+    background: rgba(0, 0, 0, 0.85);
+    color: #ffffff;
+  }
+}


### PR DESCRIPTION
## Summary
- add a hidden loading overlay in the markup
- style overlay for light & dark themes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852714161e48323b84bb38b178b944d