### PR TITLE
Add audience selector step

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,14 @@
                 <!-- Personalized welcome message will be populated by script.js -->
                 <p id="welcomeMessage" class="welcome-message" aria-live="polite"></p>
             </div>
+
+            <fieldset id="audience-selector" class="audience-selector">
+                <legend>We’re so glad you’re joining us! First, tell us how you’re arriving…</legend>
+                <button type="button" id="audience-guest" data-audience="guest">I’m a guest from CLT Gal Pals</button>
+                <button type="button" id="audience-member" data-audience="member">I’m a regular (Discord member)</button>
+            </fieldset>
+
+            <div id="rsvp-form" style="display:none;">
             <div class="main-container">
                 <div class="form-card">
             <form id="recipeForm" novalidate>

--- a/script.js
+++ b/script.js
@@ -23,26 +23,10 @@ let nextColorIndex = 0;
 const guestCodes = ["cltgalpals"];
 
 // -------------------------------------------------------------
-// Audience type detection
+// Audience type utilities
 // -------------------------------------------------------------
-(() => {
-    // Check for ?g= query param when the script loads
-    const params = new URLSearchParams(window.location.search);
-    const code = params.get('g');
-    const stored = localStorage.getItem('audienceType');
-
-    if (code && guestCodes.includes(code.toLowerCase())) {
-        // Recognized guest code => treat as guest
-        window.audienceType = 'guest';
-        localStorage.setItem('audienceType', 'guest');
-    } else if (stored) {
-        // Reuse the previously stored audience type
-        window.audienceType = stored;
-    } else {
-        // Default to member for all other cases
-        window.audienceType = 'member';
-    }
-})();
+// Default to member until the visitor makes a choice
+window.audienceType = 'member';
 
 /**
  * Determine if the current viewer is a guest.
@@ -1080,6 +1064,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function showMemberUI() {
+        window.audienceType = 'member';
         if (memberForm) memberForm.style.display = 'block';
         if (guestForm) guestForm.style.display = 'none';
         if (audienceField) audienceField.value = 'member';
@@ -1090,6 +1075,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function showGuestUI(code = 'public') {
+        window.audienceType = 'guest';
         if (memberForm) memberForm.style.display = 'none';
         if (guestForm) guestForm.style.display = 'block';
         if (audienceField) audienceField.value = 'guest';
@@ -1100,14 +1086,23 @@ document.addEventListener('DOMContentLoaded', () => {
         updateWelcome(); // refresh greeting when switching modes
     }
 
-    if (guestCode) {
-        showGuestUI(guestCode);
-    } else if (localStorage.getItem('audienceMode') === 'guest') {
-        const storedCode = localStorage.getItem('audienceCode') || 'public';
-        showGuestUI(storedCode);
-    } else {
-        showMemberUI();
+    const rsvpForm = document.getElementById('rsvp-form');
+    const audienceSelector = document.getElementById('audience-selector');
+    const guestBtn = document.getElementById('audience-guest');
+    const memberBtn = document.getElementById('audience-member');
+
+    function handleAudienceChoice(type) {
+        if (type === 'guest') {
+            showGuestUI(guestCode || 'public');
+        } else {
+            showMemberUI();
+        }
+        if (audienceSelector) audienceSelector.style.display = 'none';
+        if (rsvpForm) rsvpForm.style.display = 'block';
     }
+
+    if (guestBtn) guestBtn.addEventListener('click', () => handleAudienceChoice('guest'));
+    if (memberBtn) memberBtn.addEventListener('click', () => handleAudienceChoice('member'));
 
     if (switchToGuestBtn) {
         switchToGuestBtn.addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -615,6 +615,28 @@ button:disabled {
   padding: 0;
 }
 
+/* Audience selection step */
+#audience-selector {
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+#audience-selector button {
+  margin: 0.25rem;
+  padding: 12px 16px;
+  font-weight: 600;
+  border-radius: 8px;
+  border: 1px solid var(--accent);
+  background: white;
+  color: var(--accent);
+  cursor: pointer;
+}
+
+#audience-selector button:hover {
+  background: var(--accent);
+  color: #fff;
+}
+
 /* Recipe picker modal / sheet */
 .recipe-modal {
   position: fixed;


### PR DESCRIPTION
## Summary
- add a new audience selection section at the top of the RSVP flow
- hide the main RSVP form until the user chooses an option
- update styles for the new `audience-selector`
- adjust JavaScript to reveal the form after a choice and drop automatic audience detection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685277eb8f00832399c60abebc00d3b1