### PR TITLE
Add RSVP reveal animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -1102,18 +1102,27 @@ document.addEventListener('DOMContentLoaded', () => {
             showMemberUI();
         }
         if (audienceSelector) audienceSelector.style.display = 'none';
-        if (rsvpForm) rsvpForm.style.display = 'block';
+        if (rsvpForm) {
+            rsvpForm.style.display = 'block';
+            requestAnimationFrame(() => rsvpForm.classList.add('show'));
+        }
     }
 
     // When returning visitors have a stored selection, bypass chooser
     if (storedType === 'guest') {
         showGuestUI(localStorage.getItem('audienceCode') || guestCode || 'public');
         if (audienceSelector) audienceSelector.style.display = 'none';
-        if (rsvpForm) rsvpForm.style.display = 'block';
+        if (rsvpForm) {
+            rsvpForm.style.display = 'block';
+            requestAnimationFrame(() => rsvpForm.classList.add('show'));
+        }
     } else if (storedType === 'member') {
         showMemberUI();
         if (audienceSelector) audienceSelector.style.display = 'none';
-        if (rsvpForm) rsvpForm.style.display = 'block';
+        if (rsvpForm) {
+            rsvpForm.style.display = 'block';
+            requestAnimationFrame(() => rsvpForm.classList.add('show'));
+        }
     }
 
     if (guestBtn) guestBtn.addEventListener('click', () => handleAudienceChoice('guest'));

--- a/style.css
+++ b/style.css
@@ -655,6 +655,18 @@ button:disabled {
   transition: background-color 0.3s ease;
 }
 
+/* Animate RSVP form when revealed */
+#rsvp-form {
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+}
+
+#rsvp-form.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 .audience-button:hover {
   background: #ffdca4;
 }


### PR DESCRIPTION
## Summary
- animate RSVP form sliding into view
- trigger animation when audience type is selected or remembered

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852804833e4832390d51f0007c771ec