### PR TITLE
Enhance mobile hero with overlay and chevron

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,10 @@
     <div class="main-wrapper">
         <div class="cover-column">
             <img src="ThatSoundsSoGood_cover.jpg" alt="That Sounds So Good book cover" />
+            <div class="mobile-hero-overlay" aria-hidden="true">
+                <h1>Shared Table RSVP • June 2025</h1>
+                <span class="scroll-down">↓</span>
+            </div>
         </div>
         <div class="content-column">
             <div class="hero-text">

--- a/style.css
+++ b/style.css
@@ -112,6 +112,30 @@ h1, h2, h3, h4, h5, h6 {
 .cover-column {
   position: relative;
 }
+.mobile-hero-overlay {
+  display: none; /* only shown on mobile */
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+  padding-bottom: 1.5rem;
+  text-align: center;
+  color: #fff;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 50%, rgba(0, 0, 0, 0.6) 100%);
+}
+
+.mobile-hero-overlay h1 {
+  font-size: 1.5rem;
+  margin: 0 1rem 0.5rem;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+}
+
+.scroll-down {
+  font-size: 1.75rem;
+  animation: bounce 1.6s infinite;
+}
 .cover-column img {
   width: 100%;
   height: auto;
@@ -515,6 +539,18 @@ button:disabled {
   .hero-text {
     text-align: center;
   }
+
+  .hero-text h1 {
+    display: none; /* headline appears in overlay */
+  }
+
+  .mobile-hero-overlay {
+    display: flex;
+  }
+
+  .scroll-down {
+    display: block;
+  }
 }
 
 /* Recipe metadata card */
@@ -770,6 +806,11 @@ button:disabled {
 @keyframes fadeIn {
   from { opacity: 0; transform: translateY(20px); }
   to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes bounce {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(6px); }
 }
 
 /* Recipe detail modal overlay */


### PR DESCRIPTION
## Summary
- overlay heading on hero cover for mobile
- fade bottom of hero image and animate downward chevron
- hide duplicate heading on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685287d28f9083238cce7d1d08561e6d