### PR TITLE
Streamline RSVP name input

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,24 +27,20 @@
                 <input type="hidden" id="audienceType" name="audienceType" value="member">
                 <input type="hidden" id="audienceCode" name="audienceCode" value="">
 
-                <div id="member-form">
-                    <div class="form-group">
-                        <label for="member">Who are you? *</label>
-                        <input id="member" name="member" list="member-list" placeholder="Start typing your name…" required>
-                        <datalist id="member-list"></datalist>
-                    </div>
-                    <button type="button" id="switch-to-guest-btn" class="switch-link">Not a Discord member? RSVP as a guest.</button>
+                <div class="form-group" id="nameSelectGroup">
+                    <label for="member">Your Name *</label>
+                    <input id="member" name="member" list="member-list" placeholder="Start typing your name…" autocomplete="off" required>
+                    <datalist id="member-list"></datalist>
+                    <button type="button" id="showCustomName" class="switch-link">I'm new</button>
                 </div>
-
-                <div id="guest-form" style="display:none;">
-                    <div class="form-group">
-                        <label for="guestName">Your Name: *</label>
-                        <input id="guestName" name="guestName" type="text" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="guestEmail">Your Email (optional):</label>
-                        <input id="guestEmail" name="guestEmail" type="email">
-                    </div>
+                <div class="form-group" id="customNameGroup" style="display:none;">
+                    <label for="guestName">Your Name *</label>
+                    <input id="guestName" name="guestName" type="text">
+                    <button type="button" id="backToList" class="switch-link">Select from list</button>
+                </div>
+                <div class="form-group" id="emailGroup" style="display:none;">
+                    <label for="guestEmail">Your Email *</label>
+                    <input id="guestEmail" name="guestEmail" type="email">
                 </div>
                 <div class="form-group">
                     <label>How are you joining? *</label>


### PR DESCRIPTION
## Summary
- simplify audience logic by removing mode toggles
- use one name field with optional custom entry
- auto-switch to guest mode when typing a custom name
- require email only for guests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853b42b8a048323900a9d1c30fc1ae7