### PR TITLE
Streamline name handling in RSVP form

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,12 +34,18 @@
                 <input type="hidden" id="eventName" name="eventName" readonly>
                 <input type="hidden" id="eventDate" name="eventDate" readonly>
 
-                <div id="member-form">
-                    <div class="form-group">
-                        <label for="member">Who are you? *</label>
-                        <input id="member" name="member" list="member-list" placeholder="Start typing your name…" required>
-                        <datalist id="member-list"></datalist>
-                    </div>
+                <div class="form-group" id="nameSelectGroup">
+                    <label for="nameSelect">Your Name *</label>
+                    <select id="nameSelect" name="nameSelect" required></select>
+                </div>
+                <div class="form-group" id="nameInputGroup" style="display:none;">
+                    <label for="nameInput">Your Name *</label>
+                    <input id="nameInput" name="nameInput" type="text" placeholder="Type your name">
+                    <button type="button" id="backToList" class="switch-link">Select from list</button>
+                </div>
+                <div class="form-group" id="emailGroup" style="display:none;">
+                    <label for="email">Email Address *</label>
+                    <input id="email" name="email" type="email" placeholder="you@example.com">
                 </div>
                 <div class="form-group">
                     <label>How are you joining? *</label>


### PR DESCRIPTION
## Summary
- replace name datalist with select menu and guest input
- add conditional email field for guests
- infer audience type and adjust UI accordingly
- update validation and submission logic to include audience information

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853bd9c2e148323a45cfbc03a87e4e2