### PR TITLE
Add drinks menu support

### DIFF
--- a/config.js
+++ b/config.js
@@ -121,6 +121,18 @@ const CONFIG = {
             claimed: false,
             claimedByDiscordId: '',
             claimedAt: ''
+        },
+        {
+            id: 9,
+            name: 'Cucumber Mint Cooler',
+            description: 'Refreshing sparkling drink',
+            page: 192,
+            categories: ['Beverages / drinks (no-alcohol)'],
+            ingredients: 'cucumber; mint; soda water; lime',
+            accompaniments: '',
+            claimed: false,
+            claimedByDiscordId: '',
+            claimedAt: ''
         }
     ],
     

--- a/script.js
+++ b/script.js
@@ -111,22 +111,25 @@ const COURSE_CATEGORIES = {
     appetizer: ['Appetizer'],
     main: ['Main course', 'Stews & one-pot meals', 'Grills & BBQ', 'Rice dishes', 'Pasta, doughs & sauces'],
     side: ['Side dish', 'Salads', 'Sauces, general', 'Dressings & marinades'],
-    dessert: ['Dessert']
+    dessert: ['Dessert'],
+    drink: ['Beverages / drinks (no-alcohol)']
 };
 
-const COURSE_ORDER = ['appetizer', 'main', 'side', 'dessert'];
+const COURSE_ORDER = ['appetizer', 'main', 'side', 'dessert', 'drink'];
 const COURSE_DISPLAY_NAMES = {
     appetizer: 'Appetizers',
     main: 'Main Courses',
     side: 'Side Dishes',
-    dessert: 'Desserts'
+    dessert: 'Desserts',
+    drink: 'Drinks'
 };
 
 const COURSE_KEYWORDS = {
     dessert: ['cake', 'pie', 'cookie', 'pudding', 'tart', 'brownie'],
     appetizer: ['dip', 'starter', 'appetizer'],
     main: ['roast', 'steak', 'pasta', 'curry', 'lasagna', 'stew'],
-    side: ['salad', 'slaw', 'soup', 'dip', 'side']
+    side: ['salad', 'slaw', 'soup', 'dip', 'side'],
+    drink: ['drink', 'beverage', 'juice', 'mocktail', 'smoothie']
 };
 
 const VEG_KEYWORDS = ['tofu', 'broccoli', 'cauliflower', 'tempeh', 'seitan'];

--- a/style.css
+++ b/style.css
@@ -31,6 +31,7 @@ h1, h2, h3, h4, h5, h6 {
   --course-side: #3DA351;
   --course-dessert: #F4B84B;
   --course-appetizer: #0070A3;
+  --course-drink: #4E5FA9;
   /* accent hue pulled from the current book cover */
   --accent: #6A5AF9;
 }
@@ -336,6 +337,7 @@ h1, h2, h3, h4, h5, h6 {
 .dish-card--side       { --course-color: var(--course-side); }
 .dish-card--dessert    { --course-color: var(--course-dessert); }
 .dish-card--appetizer  { --course-color: var(--course-appetizer); }
+.dish-card--drink      { --course-color: var(--course-drink); }
 
 .dish-card--veg {
   position: relative;


### PR DESCRIPTION
## Summary
- categorize non-alcoholic beverages as `Drinks`
- show Drinks after Desserts in the menu
- color drinks cards with an indigo bar
- add a sample drink recipe

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854771b4d388323adf2bdc30a6db4dd