### PR TITLE
Fix dish card claimed name logic

### DIFF
--- a/config.js
+++ b/config.js
@@ -35,8 +35,9 @@ const CONFIG = {
             ingredients: 'romaine lettuce; croutons; parmesan; Caesar dressing',
             accompaniments: 'extra parmesan; lemon wedges',
             claimed: true,
-            claimedBy: 'AliceChef',
+            claimerName: 'AliceChef',
             claimedByDiscordId: '123456789012345678',
+            claimedByInstagramId: '',
             claimedAt: ''
         },
         {
@@ -48,8 +49,9 @@ const CONFIG = {
             ingredients: 'baguette; garlic; butter; parsley',
             accompaniments: 'marinara sauce',
             claimed: true,
-            claimedBy: 'Guest Cook',
+            claimerName: 'Guest Cook',
             claimedByDiscordId: '',
+            claimedByInstagramId: '',
             claimedAt: ''
         },
         {
@@ -61,8 +63,9 @@ const CONFIG = {
             ingredients: 'chocolate; flour; sugar; eggs; butter',
             accompaniments: 'vanilla ice cream',
             claimed: false,
-            claimedBy: '',
+            claimerName: '',
             claimedByDiscordId: '',
+            claimedByInstagramId: '',
             claimedAt: ''
         },
         {
@@ -74,8 +77,9 @@ const CONFIG = {
             ingredients: 'assorted vegetables; soy sauce; sesame oil',
             accompaniments: 'steamed rice',
             claimed: false,
-            claimedBy: '',
+            claimerName: '',
             claimedByDiscordId: '',
+            claimedByInstagramId: '',
             claimedAt: ''
         },
         {
@@ -87,8 +91,9 @@ const CONFIG = {
             ingredients: 'mixed fresh fruit',
             accompaniments: 'honey yogurt dip',
             claimed: false,
-            claimedBy: '',
+            claimerName: '',
             claimedByDiscordId: '',
+            claimedByInstagramId: '',
             claimedAt: ''
         },
         {
@@ -100,8 +105,9 @@ const CONFIG = {
             ingredients: 'pasta; seasonal vegetables; olive oil; parmesan',
             accompaniments: 'crusty bread',
             claimed: false,
-            claimedBy: '',
+            claimerName: '',
             claimedByDiscordId: '',
+            claimedByInstagramId: '',
             claimedAt: ''
         },
         {
@@ -113,8 +119,9 @@ const CONFIG = {
             ingredients: 'chicken wings; hot sauce; butter',
             accompaniments: 'celery sticks; blue cheese dip',
             claimed: false,
-            claimedBy: '',
+            claimerName: '',
             claimedByDiscordId: '',
+            claimedByInstagramId: '',
             claimedAt: ''
         },
         {
@@ -126,8 +133,9 @@ const CONFIG = {
             ingredients: 'assorted cheese; crackers; fruit',
             accompaniments: 'fig jam; sliced baguette',
             claimed: false,
-            claimedBy: '',
+            claimerName: '',
             claimedByDiscordId: '',
+            claimedByInstagramId: '',
             claimedAt: ''
         },
         {
@@ -139,7 +147,9 @@ const CONFIG = {
             ingredients: 'cucumber; mint; soda water; lime',
             accompaniments: '',
             claimed: false,
+            claimerName: '',
             claimedByDiscordId: '',
+            claimedByInstagramId: '',
             claimedAt: ''
         }
     ],

--- a/script.js
+++ b/script.js
@@ -281,7 +281,7 @@ function openRecipeDetailModal(recipeId) {
     const claimDiv = document.createElement('div');
     claimDiv.className = 'claim-status';
     if (recipe.claimed) {
-        let claimedBy = recipe.claimerName || recipe.claimedBy || recipe.displayName || '';
+        let claimedBy = recipe.claimerName || '';
         if (!claimedBy && recipe.claimedByDiscordId) {
             const form = window.recipeSignupForm;
             claimedBy = form ? form.getMemberName(recipe.claimedByDiscordId) || recipe.claimedByDiscordId : recipe.claimedByDiscordId;
@@ -495,14 +495,7 @@ class RecipeSignupForm {
             const recipe = { ...r };
             recipe.claimedByDiscordId = recipe.claimedByDiscordId || '';
             recipe.claimedByInstagramId = recipe.claimedByInstagramId || '';
-            if (recipe.claimed) {
-                const name = recipe.claimerName || recipe.claimedBy || '';
-                recipe.claimerName = name;
-                recipe.displayName = name;
-            } else {
-                recipe.claimerName = '';
-                recipe.displayName = '';
-            }
+            recipe.claimerName = recipe.claimed ? (recipe.claimerName || '') : '';
             return recipe;
         });
         this.allRecipes.forEach(r => { r.urlId = generateRecipeId(r); });
@@ -553,16 +546,14 @@ class RecipeSignupForm {
                 recipe.claimedByDiscordId = recipe.claimedByDiscordId || '';
                 recipe.claimedByInstagramId = recipe.claimedByInstagramId || '';
                 if (recipe.claimed) {
-                    let name = recipe.claimerName || recipe.displayName || recipe.claimedBy || '';
+                    let name = recipe.claimerName || '';
                     if (!name && recipe.claimedByDiscordId) {
                         const m = activeMembers.find(mem => mem.discordId === recipe.claimedByDiscordId);
                         if (m) name = m.displayName;
                     }
                     recipe.claimerName = name;
-                    recipe.displayName = name;
                 } else {
                     recipe.claimerName = '';
-                    recipe.displayName = '';
                 }
                 recipe.urlId = generateRecipeId(recipe);
                 return recipe;
@@ -1042,9 +1033,20 @@ class RecipeSignupForm {
         nameDiv.textContent = getRecipeName(recipe);
         headerInfo.appendChild(nameDiv);
 
-        let claimedBy = recipe.claimerName || recipe.claimedBy || recipe.displayName || '';
+        // Determine the display name of the person who claimed this recipe.
+        // Start with any name fields provided directly on the recipe object.
+        let claimedBy = recipe.claimerName || '';
+        // Look up Discord member names when we only have their ID.
         if (!claimedBy && recipe.claimedByDiscordId) {
             claimedBy = this.getMemberName(recipe.claimedByDiscordId) || recipe.claimedByDiscordId;
+        }
+        // Also support Instagram guests who may not have a Discord ID.
+        if (!claimedBy && recipe.claimedByInstagramId) {
+            claimedBy = recipe.claimedByInstagramId;
+        }
+        // Final fallback so something is always shown.
+        if (!claimedBy) {
+            claimedBy = recipe.memberName || 'Unknown';
         }
         if (claimedBy) {
             const claimDiv = document.createElement('div');


### PR DESCRIPTION
## Summary
- handle instagram guests & unknown claimers in `renderDishCard`
- unify claimer fields to `claimerName`, `claimedByDiscordId`, `claimedByInstagramId`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68551a084ab4832389f1d6e9e19ab5a6