### PR TITLE
Handle guest claims without names

### DIFF
--- a/code.js
+++ b/code.js
@@ -564,7 +564,12 @@ function getFormData() {
         if (!name && claimerMap[String(recipeId)]) {
           name = claimerMap[String(recipeId)];
         }
-        if (claimed && !name) missingNames.push(recipeId);
+        if (claimed && !name) {
+          missingNames.push(recipeId);
+          // Use a generic placeholder so the front-end can still show
+          // that the dish was claimed by an unnamed guest.
+          name = 'Guest';
+        }
         return name;
       })(),
       // Preserve the raw Discord ID for members so the client can link it.
@@ -575,6 +580,9 @@ function getFormData() {
         let name = memberMap[raw] || raw;
         if (!name && claimerMap[String(recipeId)]) {
           name = claimerMap[String(recipeId)];
+        }
+        if (claimed && !name) {
+          name = 'Guest';
         }
         return name;
       })()

--- a/script.js
+++ b/script.js
@@ -861,11 +861,21 @@ class RecipeSignupForm {
     }
 
     getClaimerDisplay(recipe) {
-        if (!recipe.claimer || !recipe.claimer.name) {
+        if (!recipe.claimer) {
             return 'Unknown';
         }
 
         const { name, type } = recipe.claimer;
+
+        if (!name) {
+            // When a recipe is claimed by a guest but their name wasn't
+            // recorded properly, fall back to the generic "Guest" label so
+            // the menu still shows who is bringing the dish.
+            if (recipe.claimed && type === 'guest') {
+                return 'Guest';
+            }
+            return 'Unknown';
+        }
 
         switch (type) {
             case 'member':


### PR DESCRIPTION
## Summary
- fallback to `Guest` when guest names are missing in the frontend
- supply `Guest` placeholder when backend can't resolve a claimer name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855fac519d08323a4df980660d66315