### PR TITLE
Align sheet names with backend

### DIFF
--- a/config.js
+++ b/config.js
@@ -6,11 +6,13 @@ const CONFIG = {
     // Google Apps Script Web App URL
     SCRIPT_URL: 'https://script.google.com/macros/s/AKfycbzwJyBZxKmowav0SOHl7tzcSEJ5XlbU2NFYkXaz5lI6bN5zySqi4wzTOmTg5lirSnl5/exec',
     
-    // Sheet names
+    // Sheet names (keep in sync with the backend)
     SHEETS: {
-        MEMBERS: 'Members',
-        RECIPES: 'Recipes', 
-        RSVPS: 'RSVPs'
+        USERS: 'Users',
+        EVENTS: 'Events',
+        RECIPES: 'Recipes',
+        RSVPS: 'RSVPs',
+        CLAIMS: 'Claims'
     },
     
     // API endpoints for reading data (using Google Sheets public API)

--- a/config.js
+++ b/config.js
@@ -12,7 +12,7 @@ const CONFIG = {
         EVENTS: 'Events',
         RECIPES: 'Recipes',
         RSVPS: 'RSVPs',
-        CLAIMS: 'Claims'
+        RECIPE_CLAIMS: 'Claims'
     },
     
     // API endpoints for reading data (using Google Sheets public API)

--- a/script.js
+++ b/script.js
@@ -588,7 +588,7 @@ class RecipeSignupForm {
             // 3. Destructure the nested data envelope
             const { members, recipes } = raw.data;
             
-            console.log('📊 Members found:', members.length);
+            console.log('📊 Users found:', members.length);
             console.log('🍽️ Recipes found:', recipes.length);
             
             // 4. Filter the clean arrays


### PR DESCRIPTION
## Summary
- use the backend sheet names in `config.js`
- tweak console log to say "Users" instead of "Members"

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68579eb5b9d88323b18e408afb0c7ab8