### PR TITLE
Add hidden display name field for members

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,6 +135,7 @@
                                 <div id="member-select-help" class="field-help">
                                     Select your name from the member list
                                 </div>
+                                <input type="hidden" id="member-display-name" name="displayName">
                             </div>
                         </fieldset>
 

--- a/js/components/form-handler.js
+++ b/js/components/form-handler.js
@@ -132,13 +132,21 @@ class FormHandler {
     handleMemberSelection() {
       const memberSelect = document.getElementById('member-select');
       const selectedOption = memberSelect.options[memberSelect.selectedIndex];
-      
+      const displayNameInput = document.getElementById('member-display-name');
+
       if (selectedOption.value) {
         this.formData.memberId = selectedOption.value;
         this.formData.displayName = selectedOption.textContent;
         this.formData.discordId = selectedOption.dataset.discordId;
+        if (displayNameInput) {
+          displayNameInput.value = selectedOption.textContent;
+        }
+      } else {
+        if (displayNameInput) {
+          displayNameInput.value = '';
+        }
       }
-      
+
       this.updateNavigationButtons();
     }
     


### PR DESCRIPTION
## Summary
- store selected member display name in a hidden input
- sync member selection value to the new hidden field for submission

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68599dadce088323af67e10dd9618d6a