### PR TITLE
Fix display name validation for members

### DIFF
--- a/js/components/form-handler.js
+++ b/js/components/form-handler.js
@@ -117,12 +117,30 @@ class FormHandler {
     handleUserTypeChange() {
       const userType = document.querySelector('input[name="userType"]:checked')?.value;
       
+      const guestName = document.getElementById('guest-name');
+      const guestInstagram = document.getElementById('guest-instagram');
+      const guestEmail = document.getElementById('guest-email');
+      const hiddenDisplayName = document.getElementById('member-display-name-hidden');
+      const hiddenDiscordId = document.getElementById('member-discord-id-hidden');
+
       if (userType === 'member') {
         document.getElementById('step-member-info').style.display = 'block';
         document.getElementById('step-guest-info').style.display = 'none';
+
+        if (guestName) guestName.disabled = true;
+        if (guestInstagram) guestInstagram.disabled = true;
+        if (guestEmail) guestEmail.disabled = true;
+        if (hiddenDisplayName) hiddenDisplayName.disabled = false;
+        if (hiddenDiscordId) hiddenDiscordId.disabled = false;
       } else if (userType === 'guest') {
         document.getElementById('step-member-info').style.display = 'none';
         document.getElementById('step-guest-info').style.display = 'block';
+
+        if (guestName) guestName.disabled = false;
+        if (guestInstagram) guestInstagram.disabled = false;
+        if (guestEmail) guestEmail.disabled = false;
+        if (hiddenDisplayName) hiddenDisplayName.disabled = true;
+        if (hiddenDiscordId) hiddenDiscordId.disabled = true;
       }
       
       this.formData.userType = userType;


### PR DESCRIPTION
## Summary
- keep guest inputs from overwriting the hidden member displayName value by disabling them when not in use

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859b27c28a483239ffe9456a486ef11